### PR TITLE
refactor(readme): some small optimizations on the readme files contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 The Vanilla StarterKit for Handlebars is meant to be used as a demonstration of a Handlebars-based project in Pattern Lab.
 
-## Requirements
-
-The Vanilla StarterKit for Handlebars requires the following PatternEngine:
-
-- `@pattern-lab/patternengine-node-handlebars`: [npm](https://www.npmjs.com/package/@pattern-lab/patternengine-node-handlebars), [Github](https://github.com/pattern-lab/patternengine-node-handlebars)
-
 ## Install
 
 [Installation Instructions](http://patternlab.io/docs/advanced-starterkits.html)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Vanilla StarterKit for Handlebars is meant to be used as a demonstration of 
 
 ## Install
 
-[Installation Instructions](http://patternlab.io/docs/advanced-starterkits.html)
+[Installation Instructions](https://patternlab.io/docs/starterkits/)
 
 ## Edit Files
 


### PR DESCRIPTION
### Summary of changes
- `@pattern-lab/patternengine-node-handlebars` is not a requirement anymore as it's now baked into patternlab-node directly, compare to the first line of content on the archived repos readme: https://github.com/pattern-lab/patternengine-node-handlebars#readme
- fix(readme): link target page within the documentation: another leftover regarding the new documentation (structure), compare to the [older pages archived version](https://web.archive.org/web/20180705064158/http://patternlab.io/docs/advanced-starterkits.html) that https://patternlab.io/docs/starterkits/ is its successor in the new structure.