### PR TITLE
refactor: moved dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "publish": "npx np --no-tests"
   },
   "dependencies": {
+  },
+  "devDependencies": {
     "node-sass": "^6.0.1",
     "node-sass-glob-importer": "^5.3.2"
   }


### PR DESCRIPTION
Solves parts of [#1380](https://github.com/pattern-lab/patternlab-node/issues/1380)

### Summary of changes:

Moving `dependencies` to `devDependencies` that are only used during preparding the package `@pattern-lab/starterkit-handlebars-vanilla` for publishing.